### PR TITLE
Support 1.12

### DIFF
--- a/main/java/com/webkonsept/minecraft/lagmeter/LagMeter.java
+++ b/main/java/com/webkonsept/minecraft/lagmeter/LagMeter.java
@@ -817,7 +817,7 @@ public class LagMeter extends JavaPlugin{
 				double[] mem = this.getMemory();
 				this.sendMessage(sender, Severity.INFO, String.format("%,.2f MB/%,.2f MB used (%.2f%% free)", mem[0], mem[1], mem[3]));
 
-				this.sendMessage(sender, Severity.INFO, String.format("%,d players online", Bukkit.getOnlinePlayers().size()));
+				this.sendMessage(sender, Severity.INFO, String.format("%,d players online", Bukkit.getServer().getOnlinePlayers().size()));
 
 				if (this.displayChunks) {
 					this.sendMessage(sender, Severity.INFO, String.format("%,d", this.getChunksLoaded()));

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.11.2-R0.1-SNAPSHOT</version>
+            <version>1.12-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
 


### PR DESCRIPTION
Lagmeter wasn't working for me on 1.12, I was getting:

<pre>
[00:00:00] [Server thread/WARN]: [LagMeter] Task #18 for LagMeter v1.16.0 generated an exception
java.lang.NoSuchMethodError: org.bukkit.Server._INVALID_getOnlinePlayers()[Lorg/bukkit/entity/Player;
        at com.webkonsept.minecraft.lagmeter.LagMeterPoller.run(LagMeterPoller.java:16) ~[?:?]
        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftTask.run(CraftTask.java:71) ~[2017-06-21-22-45-40-spigot-1.12-jenkins-1322.jar:git-Spigot-4df3c0c-03f1e37]
        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:353) [2017-06-21-22-45-40-spigot-1.12-jenkins-1322.jar:git-Spigot-4df3c0c-03f1e37]
        at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:738) [2017-06-21-22-45-40-spigot-1.12-jenkins-1322.jar:git-Spigot-4df3c0c-03f1e37]
        at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:405) [2017-06-21-22-45-40-spigot-1.12-jenkins-1322.jar:git-Spigot-4df3c0c-03f1e37]
        at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:678) [2017-06-21-22-45-40-spigot-1.12-jenkins-1322.jar:git-Spigot-4df3c0c-03f1e37]
        at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:576) [2017-06-21-22-45-40-spigot-1.12-jenkins-1322.jar:git-Spigot-4df3c0c-03f1e37]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
</pre>

.. and the lag log wasn't updated.

This PR fixes it; a version built from this is working fine on our live 1.12 server.